### PR TITLE
tests: Invoke application in-process

### DIFF
--- a/src/tomlize/__main__.py
+++ b/src/tomlize/__main__.py
@@ -1,4 +1,6 @@
+import sys
+
 from .main import main
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/src/tomlize/cli.py
+++ b/src/tomlize/cli.py
@@ -2,8 +2,8 @@ import argparse
 import pathlib
 
 
-def parse_args():
+def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("input_file", type=pathlib.Path)
     parser.add_argument("output_file", type=pathlib.Path, nargs="?")
-    return parser.parse_args()
+    return parser.parse_args(args=args)

--- a/src/tomlize/main.py
+++ b/src/tomlize/main.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import coloredlogs
 import toml
 
@@ -5,19 +7,31 @@ from . import loaders
 from .cli import parse_args
 
 
-def main():
-    args = parse_args()
+def _convert(*, input_file: pathlib.Path, existing_config: dict | None) -> dict:
     result = {}
-    coloredlogs.install(level="INFO", fmt="%(message)s")
+    if existing_config:
+        result.update(existing_config)
 
-    if args.output_file and args.output_file.exists():
-        result.update(toml.loads(args.output_file.read_text()))
-
-    if args.input_file.name == "setup.py":
-        data = loaders.setup_py.extract(args.input_file)
+    if input_file.name == "setup.py":
+        data = loaders.setup_py.extract(input_file)
         # TODO: Merge with existing data
         result.update(data)
 
+    return result
+
+
+def main(argv):
+    args = parse_args(argv)
+    coloredlogs.install(level="INFO", fmt="%(message)s")
+
+    existing_config = None
+    if args.output_file and args.output_file.exists():
+        existing_config = toml.loads(args.output_file.read_text())
+
+    result = _convert(
+        input_file=args.input_file,
+        existing_config=existing_config,
+    )
     output = toml.dumps(result)
     if args.output_file:
         args.output_file.write_text(output)

--- a/tests/end2end/test_setup_py.py
+++ b/tests/end2end/test_setup_py.py
@@ -1,4 +1,6 @@
 import contextlib
+import os
+import pathlib
 import pprint
 import shutil
 import subprocess
@@ -7,6 +9,8 @@ import tarfile
 
 import pkginfo
 import pytest
+
+from tomlize import main
 
 from .. import utils
 
@@ -49,10 +53,8 @@ def empty_pyproject_toml(tmp_path):
 
 
 def run(*args):
-    subprocess.run(
-        [sys.executable, "-m", "tomlize", *args],
-        check=True,
-    )
+    _args = [os.fspath(arg) if isinstance(arg, pathlib.Path) else arg for arg in args]
+    main.main(_args)
 
 
 def test_end_to_end_stdout(setup_py):


### PR DESCRIPTION
Instead of relying on subprocess calls, invoke the `main` function in tests. This makes it easier to debug failing tests.