### PR TITLE
Assume the output file is `pyproject.toml`

### DIFF
--- a/src/tomlize/cli.py
+++ b/src/tomlize/cli.py
@@ -5,5 +5,4 @@ import pathlib
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("input_file", type=pathlib.Path)
-    parser.add_argument("output_file", type=pathlib.Path, nargs="?")
     return parser.parse_args(args=args)

--- a/src/tomlize/main.py
+++ b/src/tomlize/main.py
@@ -23,17 +23,15 @@ def _convert(*, input_file: pathlib.Path, existing_config: dict | None) -> dict:
 def main(argv):
     args = parse_args(argv)
     coloredlogs.install(level="INFO", fmt="%(message)s")
+    output_file = pathlib.Path("pyproject.toml")
 
     existing_config = None
-    if args.output_file and args.output_file.exists():
-        existing_config = toml.loads(args.output_file.read_text())
+    if output_file.exists():
+        existing_config = toml.loads(output_file.read_text())
 
     result = _convert(
         input_file=args.input_file,
         existing_config=existing_config,
     )
     output = toml.dumps(result)
-    if args.output_file:
-        args.output_file.write_text(output)
-    else:
-        print(output)
+    output_file.write_text(output)

--- a/tests/end2end/test_setup_py.py
+++ b/tests/end2end/test_setup_py.py
@@ -15,6 +15,11 @@ from tomlize import main
 from .. import utils
 
 
+@pytest.fixture(autouse=True)
+def tmp_ws(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def setup_py(tmp_path):
     f = tmp_path / "setup.py"
@@ -59,10 +64,11 @@ def run(*args):
 
 def test_end_to_end_stdout(setup_py):
     run(setup_py)
+    print(pathlib.Path("pyproject.toml").read_text())
 
 
 def test_end_to_end_empty(setup_py, empty_pyproject_toml):
-    run(setup_py, empty_pyproject_toml)
+    run(setup_py)
     assert (
         empty_pyproject_toml.read_text()
         == """\
@@ -135,7 +141,7 @@ def transform_setuppy(project_folder):
     print(setup_py.read_text())
     print(f"{'':*^50}")
     subprocess.run(
-        [sys.executable, "-m", "tomlize", setup_py, "pyproject.toml"],
+        [sys.executable, "-m", "tomlize", setup_py],
         check=True,
     )
     setup_py.unlink()


### PR DESCRIPTION
We will always write to that file, there is no need for the user to provide it. This will allow us to do some future assumptions where we will be modifying other files like `setup.py` as we migrate data from one file to another.